### PR TITLE
fix mixed & low score issue

### DIFF
--- a/metacritic.php
+++ b/metacritic.php
@@ -74,11 +74,11 @@ class MetacriticAPI
                 $name = trim($element->plaintext);
             }
 
-            foreach ($html->find('div[class=metascore_w xlarge game positive] span') as $element) {
+            foreach ($html->find('div.metascore_w.xlarge.game span') as $element) {
                 $metascritic_score = intval($element->plaintext);
             }
 
-            foreach ($html->find("div[class=metascore_w user large game positive]") as $element) {
+            foreach ($html->find("div.metascore_w.user.large.game") as $element) {
                 $user_score = floatval($element->plaintext);
             }
 


### PR DESCRIPTION
The script was not scraping scores for games with "not positive" metacritic and user  scores.

You can replicate the problem by searching for the following game which has a "mixed" score: [NECROMUNDA: HIRED GUN](https://www.metacritic.com/game/pc/necromunda-hired-gun)

The problem was with the selector used.